### PR TITLE
Fix playwright worker sqlite native binding and shared DB mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ x-common-service: &common-service
         - anycrawl-network
     volumes:
         - ./storage:/usr/src/app/storage
+        - ./db:/usr/src/app/db
 
 x-common-env: &common-env
     NODE_ENV: ${NODE_ENV:-production}

--- a/packages/scrape/Dockerfile.playwright
+++ b/packages/scrape/Dockerfile.playwright
@@ -25,7 +25,8 @@ COPY packages/db/package.json ./packages/db/package.json
 COPY packages/ai/package.json ./packages/ai/package.json
 COPY packages/template-client/package.json ./packages/template-client/package.json
 COPY packages/typescript-config/package.json ./packages/typescript-config/package.json
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile --prod=false
+RUN --mount=type=cache,id=pnpm-playwright-glibc,target=/pnpm/store \
+    npm_config_build_from_source=true pnpm install --frozen-lockfile --prod=false
 COPY . .
 RUN pnpm build --filter=@anycrawl/libs --filter=@anycrawl/db --filter=@anycrawl/template-client --filter=@anycrawl/ai --filter=@anycrawl/scrape
 RUN rm -rf node_modules
@@ -53,9 +54,11 @@ COPY --from=build /usr/src/app/packages/db/package.json /usr/src/app/packages/db
 COPY --from=build /usr/src/app/packages/ai/package.json /usr/src/app/packages/ai/package.json
 COPY --from=build /usr/src/app/packages/template-client/package.json /usr/src/app/packages/template-client/package.json
 
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile
-# Ensure native modules rebuilt for current platform
-RUN pnpm rebuild better-sqlite3
+RUN --mount=type=cache,id=pnpm-playwright-glibc,target=/pnpm/store \
+    npm_config_build_from_source=true pnpm install --prod --frozen-lockfile
+# Ensure better-sqlite3 is compiled inside this glibc image (avoid musl prebuild artifacts)
+RUN cd /usr/src/app/node_modules/.pnpm/better-sqlite3@11.10.0/node_modules/better-sqlite3 && \
+    npm run build-release
 ENV ANYCRAWL_AVAILABLE_ENGINES=playwright
 
 RUN npx -y playwright install chromium


### PR DESCRIPTION
## Summary
- add shared SQLite mount (`./db:/usr/src/app/db`) to common docker-compose service block so all workers can access DB
- fix `scrape-playwright` native sqlite binding crash by isolating pnpm cache for glibc image (`pnpm-playwright-glibc`)
- force in-image build of `better-sqlite3` (`npm run build-release`) to avoid musl artifact reuse

## Problem fixed
- `scrape-playwright` crashed with `ERR_DLOPEN_FAILED` / `libc.musl-x86_64.so.1`
- workers without DB mount failed with `Cannot open database because the directory does not exist`

## Validation
- `docker compose ps -a scrape-playwright` => Up
- `POST /v1/scrape` with `engine=playwright` on `https://example.com` => `success: true`
