### PR TITLE
fix(search): surface upstream errors and release beta.37

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-beta.37] - 2026-09-07
+
+### Added
+
+- **Monitoring recovery** — persist check and notification intents, serialize checks through post-processing, and recover unfinished work after queue failures or worker restarts.
+- **Monitoring API and JS SDK 0.0.9** — cursor pagination, an owner-scoped changes feed, full snapshot details, check/notification history, nullable configuration updates, and specific response types.
+- Facebook, Instagram, and YouTube scraper templates, with validated PostgreSQL/SQLite SQL generation and template registration tooling.
+- Per-request Playwright humanization through CloakBrowser, with default/careful presets and pointer warm-up.
+
+### Fixed
+
+- Propagate search upstream parameter errors as HTTP 400 and other upstream failures as HTTP 502 instead of successful empty results; await page callbacks and prevent partial searches from dispatching follow-up scrapes or being charged.
+- Align live-test output assertions with requested formats and real page content; use a controlled HTTP status fixture, validate actual JSON extraction output, and give real multi-call LLM checks an explicit functional time budget.
+- Enforce webhook owner isolation and validate the final merged monitor configuration; preserve configuration revisions and complete comparison content, and report unavailable AI judgments as unknown.
+- Recover email/webhook delivery with stable IDs and retryable intent records; protect pending work during retention and prevent hidden checks from orphaned or inactive managed tasks.
+- Align SQLite/PostgreSQL transactions and migrations, including the SQLite job-billing schema repair.
+- Declare the missing direct monitor-test dependency and isolate production compilation and Docker context from test files while retaining full type checks and tests.
+
+### Upgrade notes
+
+- Stop and drain old monitoring producers, back up and migrate the target database, then start the new API, Scheduler, and Workers together. Do not run old and new monitoring producers concurrently.
+- New migrations: PostgreSQL `0026_monitor_workflow.sql`; SQLite `0021_monitor_workflow.sql` and `0022_repair_sqlite_job_billing.sql`. Historical alerts are not replayed; incomplete historical snapshots remain visible but do not become new comparison baselines. Keep the new workflow tables if rolling back.
+- Monitor country pinning is explicitly unsupported and new country requests return HTTP 400. `ignore_selectors` filters literal text lines. Email alerts require recipients; price/JSON/mixed monitoring requires an extraction schema.
+- New SDK cursor-pagination methods require the updated server; the existing array-returning history methods remain available.
+
 ## [1.0.0-beta.36] - 2026-08-12
 
 ### Added

--- a/apps/api/src/__tests__/helpers/httpStatusFixture.ts
+++ b/apps/api/src/__tests__/helpers/httpStatusFixture.ts
@@ -1,0 +1,49 @@
+import { createServer } from "node:http";
+import { connect, type AddressInfo, type Socket } from "node:net";
+
+/** A real HTTP origin and loopback-only forwarding proxy for status tests. */
+export async function startHttpStatusFixture() {
+    const sockets = new Set<Socket>();
+    const hits = new Map<number, number>();
+    const server = createServer((req, res) => {
+        const path = new URL(req.url || "/", "http://fixture.local").pathname;
+        const status = path === "/status/403" ? 403 : path === "/status/404" ? 404 : 200;
+        hits.set(status, (hits.get(status) || 0) + 1);
+        res.writeHead(status, { "Content-Type": "text/html; charset=utf-8", "Connection": "close" });
+        res.end(`<html><head><title>HTTP ${status}</title></head><body><main>${status} ${status === 403 ? "Forbidden" : status === 404 ? "Not Found" : "OK"}</main></body></html>`);
+    });
+    server.on("connection", socket => {
+        sockets.add(socket);
+        socket.once("close", () => sockets.delete(socket));
+    });
+    server.on("connect", (req, client, head) => {
+        const destination = new URL(`http://${req.url}`);
+        const port = (server.address() as AddressInfo).port;
+        if (destination.hostname !== "127.0.0.1" || Number(destination.port) !== port) {
+            client.end("HTTP/1.1 403 Forbidden\r\n\r\n");
+            return;
+        }
+        const upstream = connect(port, "127.0.0.1", () => {
+            client.write("HTTP/1.1 200 Connection Established\r\n\r\n");
+            if (head.length) upstream.write(head);
+            client.pipe(upstream);
+            upstream.pipe(client);
+        });
+        client.on("error", () => upstream.destroy());
+        client.on("close", () => upstream.destroy());
+        upstream.on("error", () => client.destroy());
+    });
+    await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", resolve);
+    });
+    const url = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+    return {
+        url,
+        hits,
+        close: async () => {
+            for (const socket of sockets) socket.destroy();
+            await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+        },
+    };
+}

--- a/apps/api/src/__tests__/jsonSchema.test.ts
+++ b/apps/api/src/__tests__/jsonSchema.test.ts
@@ -1,166 +1,56 @@
-import { describe, expect, it, beforeAll } from "@jest/globals";
+import { describe, expect, it } from "@jest/globals";
 import request from "supertest";
+import { z } from "zod";
 
 const BASE_URL = process.env.ANYCRAWL_BASE_URL || "http://127.0.0.1:8080";
-const TIMEOUT = 30000;
+const REQUEST_TIMEOUT = 120_000;
+const TEST_TIMEOUT = REQUEST_TIMEOUT + 15_000;
+const pageSchema = {
+    type: "object",
+    properties: { title: { type: "string" }, description: { type: "string" } },
+    required: ["title", "description"],
+};
+const linkSchema = {
+    type: "object",
+    properties: { label: { type: "string" }, href: { type: "string" } },
+    required: ["label", "href"],
+};
+const pageOutput = z.object({ title: z.string().regex(/example domain/i), description: z.string().min(1) });
+const linksOutput = z.array(z.object({ label: z.string().min(1), href: z.string().url() })).min(1);
 
-describe("JSON Schema Validation (via API)", () => {
-    beforeAll(() => {
-        process.env.ANYCRAWL_API_AUTH_ENABLED = "false";
-    });
-
-    it("should accept valid simple object schema in scrape request", async () => {
-        const response = await request(BASE_URL)
-            .post("/v1/scrape")
-            .timeout(TIMEOUT)
-            .send({
-                url: "https://example.com",
-                engine: "cheerio",
-                formats: ["json"],
-                json_options: {
-                    schema: {
-                        type: "object",
-                        properties: {
-                            title: { type: "string" },
-                            description: { type: "string" }
-                        },
-                        required: ["title"]
-                    },
-                    user_prompt: "Extract title and description"
-                }
-            });
-
+// These exercise real extraction. Input-only rejection tests below never call an LLM.
+describe("JSON extraction through the API", () => {
+    const cases = [
+        { name: "object", schema: pageSchema, output: pageOutput },
+        { name: "nested object", schema: { type: "object", properties: { page: pageSchema }, required: ["page"] }, output: z.object({ page: pageOutput }) },
+        // The existing extractor normalizes a root array to an object with items.
+        { name: "root array", schema: { type: "array", items: linkSchema }, output: z.object({ items: linksOutput }) },
+        { name: "nested object with array", schema: { type: "object", properties: { page: pageSchema, links: { type: "array", items: linkSchema } }, required: ["page", "links"] }, output: z.object({ page: pageOutput, links: linksOutput }) },
+    ];
+    it.each(cases)("extracts and validates $name", async ({ name, schema, output }) => {
+        const started = Date.now();
+        const response = await request(BASE_URL).post("/v1/scrape").timeout(REQUEST_TIMEOUT).send({
+            url: "https://example.com/", engine: "cheerio", formats: ["json"],
+            json_options: { schema, user_prompt: "Extract the page title, description, and hyperlinks that are present in the input. Preserve the actual hyperlink URLs." },
+        });
+        console.info(`JSON extraction (${name}) duration: ${Date.now() - started} ms`);
         expect(response.status).toBe(200);
         expect(response.body.success).toBe(true);
-    }, TIMEOUT);
-
-    it("should accept nested object schema", async () => {
-        const response = await request(BASE_URL)
-            .post("/v1/scrape")
-            .timeout(TIMEOUT)
-            .send({
-                url: "https://example.com",
-                engine: "cheerio",
-                formats: ["json"],
-                json_options: {
-                    schema: {
-                        type: "object",
-                        properties: {
-                            user: {
-                                type: "object",
-                                properties: {
-                                    name: { type: "string" },
-                                    email: { type: "string" }
-                                }
-                            }
-                        }
-                    }
-                }
-            });
-
-        expect(response.status).toBe(200);
-        expect(response.body.success).toBe(true);
-    }, TIMEOUT);
-
-    it("should reject invalid schema type", async () => {
-        const response = await request(BASE_URL)
-            .post("/v1/scrape")
-            .timeout(TIMEOUT)
-            .send({
-                url: "https://example.com",
-                engine: "cheerio",
-                formats: ["json"],
-                json_options: {
-                    schema: {
-                        type: "invalid_type", // Invalid type
-                        properties: {
-                            title: { type: "string" }
-                        }
-                    }
-                }
-            });
-
-        // Should return validation error
-        expect(response.status).toBe(400);
-        expect(response.body.success).toBe(false);
-        expect(response.body.error).toBeDefined();
-    }, TIMEOUT);
-
-    it("should reject invalid properties type", async () => {
-        const response = await request(BASE_URL)
-            .post("/v1/scrape")
-            .timeout(TIMEOUT)
-            .send({
-                url: "https://example.com",
-                engine: "cheerio",
-                formats: ["json"],
-                json_options: {
-                    schema: {
-                        type: "object",
-                        properties: "invalid" // properties should be an object, not a string
-                    }
-                }
-            });
-
-        expect(response.status).toBe(400);
-        expect(response.body.success).toBe(false);
-    }, TIMEOUT);
-
-    it("should accept array schema", async () => {
-        const response = await request(BASE_URL)
-            .post("/v1/scrape")
-            .timeout(TIMEOUT)
-            .send({
-                url: "https://example.com",
-                engine: "cheerio",
-                formats: ["json"],
-                json_options: {
-                    schema: {
-                        type: "array",
-                        items: {
-                            type: "object",
-                            properties: {
-                                id: { type: "number" },
-                                name: { type: "string" }
-                            }
-                        }
-                    }
-                }
-            });
-
-        expect(response.status).toBe(200);
-        expect(response.body.success).toBe(true);
-    }, TIMEOUT);
-
-    it("should accept complex nested schema", async () => {
-        const response = await request(BASE_URL)
-            .post("/v1/scrape")
-            .timeout(TIMEOUT)
-            .send({
-                url: "https://example.com",
-                engine: "cheerio",
-                formats: ["json"],
-                json_options: {
-                    schema: {
-                        type: "object",
-                        properties: {
-                            company_mission: { type: "string" },
-                            is_open_source: {
-                                type: "object",
-                                properties: {
-                                    value: { type: "boolean" },
-                                    repo_url: { type: "string" }
-                                }
-                            },
-                            employee_count: { type: "number" }
-                        },
-                        required: ["company_mission"]
-                    }
-                }
-            });
-
-        expect(response.status).toBe(200);
-        expect(response.body.success).toBe(true);
-    }, TIMEOUT);
+        expect(response.body.data.status).toBe("completed");
+        expect(response.body.data.json).toBeDefined();
+        expect(() => output.parse(response.body.data.json)).not.toThrow();
+    }, TEST_TIMEOUT);
 });
 
+describe("JSON schema input validation through the API", () => {
+    it.each([
+        { type: "invalid_type", properties: { title: { type: "string" } } },
+        { type: "object", properties: "invalid" },
+    ])("rejects invalid schema before extraction: %j", async (schema) => {
+        const response = await request(BASE_URL).post("/v1/scrape").timeout(10_000).send({
+            url: "https://example.com/", engine: "cheerio", formats: ["json"], json_options: { schema },
+        });
+        expect(response.status).toBe(400);
+        expect(response.body.success).toBe(false);
+    }, 15_000);
+});

--- a/apps/api/src/__tests__/scrape.test.ts
+++ b/apps/api/src/__tests__/scrape.test.ts
@@ -1,116 +1,73 @@
-import { describe, expect, it } from "@jest/globals";
+import { afterAll, beforeAll, describe, expect, it } from "@jest/globals";
 import request from "supertest";
+import { startHttpStatusFixture } from "./helpers/httpStatusFixture.js";
 
-const TEST_URL = "http://127.0.0.1:8080";
-const TIMEOUT = 30000; // 30 seconds
+const BASE_URL = process.env.ANYCRAWL_BASE_URL || "http://127.0.0.1:8080";
+// Functional live checks include queueing and the documented auto-proxy budget.
+const REQUEST_TIMEOUT = 120_000;
+const TEST_TIMEOUT = REQUEST_TIMEOUT + 15_000;
+const engines = ["cheerio", "playwright", "puppeteer"] as const;
 
 describe("Scrape API", () => {
-    beforeAll(() => {
-        process.env.ANYCRAWL_API_AUTH_ENABLED = "false";
-    });
+    let fixture: Awaited<ReturnType<typeof startHttpStatusFixture>>;
+    beforeAll(async () => { fixture = await startHttpStatusFixture(); });
+    afterAll(async () => { await fixture?.close(); });
 
     it("health check", async () => {
-        const response = await request(TEST_URL).get("/");
+        const response = await request(BASE_URL).get("/");
         expect(response.status).toBe(200);
         expect(response.text).toBe("Hello World");
     });
 
-    it("should return failed when 403 forbidden", async () => {
-        const response = await request(TEST_URL).post("/v1/scrape").timeout(TIMEOUT).send({
-            url: "https://httpstat.us/403",
+    it.each([403, 404])("reports a real HTTP %i response as a failed scrape", async (status) => {
+        const response = await request(BASE_URL).post("/v1/scrape").timeout(REQUEST_TIMEOUT).send({
+            url: `${fixture.url}/status/${status}`,
+            proxy: fixture.url,
             engine: "cheerio",
+            formats: ["html"],
         });
+        expect(fixture.hits.get(status)).toBeGreaterThan(0);
         expect(response.status).toBe(200);
-        expect(response.body.success).toBe(true);
-        expect(response.body.data.status).toBe("failed");
-        expect(response.body.data.error.toLowerCase()).toContain("request blocked");
-    }, 10000);
-    it("should return success when 200 ok with cheerio", async () => {
-        const response = await request(TEST_URL).post("/v1/scrape").timeout(TIMEOUT).send({
-            url: "https://example.com",
-            engine: "cheerio",
-        });
-        expect(response.status).toBe(200);
-        expect(response.body.success).toBe(true);
-        expect(response.body.data.status).toBe("completed");
-        expect(response.body.data.html.toLowerCase()).toContain("200 ok");
-    }, 10000);
+        expect(response.body.success).toBe(false);
+        expect(response.body.error).toBe("Scrape task failed");
+        expect(response.body.data).toMatchObject({ status: "failed", type: "http_error", code: status });
+    }, TEST_TIMEOUT);
 
-    it("should return success when 200 ok with playwright", async () => {
-        const response = await request(TEST_URL).post("/v1/scrape").timeout(TIMEOUT).send({
-            url: "https://example.com/",
-            engine: "playwright",
+    it.each(engines)("returns requested HTML and Markdown with %s", async (engine) => {
+        const response = await request(BASE_URL).post("/v1/scrape").timeout(REQUEST_TIMEOUT).send({
+            url: "https://example.com/", engine, formats: ["html", "markdown"],
         });
         expect(response.status).toBe(200);
         expect(response.body.success).toBe(true);
         expect(response.body.data.status).toBe("completed");
-        expect(response.body.data.html.toLowerCase()).toContain("200 ok");
-    }, 10000);
-    it("should return success when 200 ok with puppeteer", async () => {
-        const response = await request(TEST_URL).post("/v1/scrape").timeout(TIMEOUT).send({
-            url: "https://example.com/",
-            engine: "puppeteer",
-        });
-        expect(response.status).toBe(200);
-        expect(response.body.success).toBe(true);
-        expect(response.body.data.status).toBe("completed");
-        expect(response.body.data.html.toLowerCase()).toContain("200 ok");
-    });
+        expect(response.body.data.html).toMatch(/example domain/i);
+        expect(response.body.data.markdown).toMatch(/example domain/i);
+    }, TEST_TIMEOUT);
 
-    it("should return success when 404 not found", async () => {
-        const response = await request(TEST_URL).post("/v1/scrape").timeout(TIMEOUT).send({
-            url: "https://httpstat.us/404",
-            engine: "cheerio",
+    it("defaults to Markdown without returning unrequested HTML", async () => {
+        const response = await request(BASE_URL).post("/v1/scrape").timeout(REQUEST_TIMEOUT).send({
+            url: "https://example.com/", engine: "cheerio",
         });
         expect(response.status).toBe(200);
         expect(response.body.success).toBe(true);
         expect(response.body.data.status).toBe("completed");
-        expect(response.body.data.html.toLowerCase()).toContain("404 not found");
-    });
+        expect(response.body.data.markdown).toMatch(/example domain/i);
+        expect(response.body.data).not.toHaveProperty("html");
+    }, TEST_TIMEOUT);
 
-    it("should return success when 200 ok with cheerio and expired ssl", async () => {
-        const response = await request(TEST_URL).post("/v1/scrape").timeout(TIMEOUT).send({
-            url: "https://expired.badssl.com/",
-            engine: "cheerio",
+    it.each(engines)("honors the configured SSL policy with %s", async (engine) => {
+        const response = await request(BASE_URL).post("/v1/scrape").timeout(REQUEST_TIMEOUT).send({
+            url: "https://expired.badssl.com/", engine, formats: ["html"],
         });
         expect(response.status).toBe(200);
-        expect(response.body.success).toBe(true);
         if (process.env.ANYCRAWL_IGNORE_SSL_ERROR === "true") {
+            expect(response.body.success).toBe(true);
             expect(response.body.data.status).toBe("completed");
-            expect(response.body.data.html.toLowerCase()).toContain("expired");
+            expect(response.body.data.html).toMatch(/expired/i);
         } else {
+            expect(response.body.success).toBe(false);
             expect(response.body.data.status).toBe("failed");
-            expect(response.body.data.error.toLowerCase()).toContain("ssl");
+            expect(response.body.message).toMatch(/ssl|certificate/i);
         }
-    });
-    it("should return success when 200 ok with playwright and expired ssl", async () => {
-        const response = await request(TEST_URL).post("/v1/scrape").timeout(TIMEOUT).send({
-            url: "https://expired.badssl.com/",
-            engine: "playwright",
-        });
-        expect(response.status).toBe(200);
-        expect(response.body.success).toBe(true);
-        if (process.env.ANYCRAWL_IGNORE_SSL_ERROR === "true") {
-            expect(response.body.data.status).toBe("completed");
-            expect(response.body.data.html.toLowerCase()).toContain("expired");
-        } else {
-            expect(response.body.data.status).toBe("failed");
-            expect(response.body.data.error.toLowerCase()).toContain("ssl");
-        }
-    });
-    it("should return success when 200 ok with puppeteer and expired ssl", async () => {
-        const response = await request(TEST_URL).post("/v1/scrape").timeout(TIMEOUT).send({
-            url: "https://expired.badssl.com/",
-            engine: "puppeteer",
-        });
-        expect(response.status).toBe(200);
-        expect(response.body.success).toBe(true);
-        if (process.env.ANYCRAWL_IGNORE_SSL_ERROR === "true") {
-            expect(response.body.data.status).toBe("completed");
-            expect(response.body.data.html.toLowerCase()).toContain("expired");
-        } else {
-            expect(response.body.data.status).toBe("failed");
-            expect(response.body.data.error.toLowerCase()).toContain("ssl");
-        }
-    });
+    }, TEST_TIMEOUT);
 });

--- a/apps/api/src/__tests__/search.test.ts
+++ b/apps/api/src/__tests__/search.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
 import request from "supertest";
 
-const TEST_URL = "http://127.0.0.1:8080";
+const TEST_URL = process.env.ANYCRAWL_BASE_URL || "http://127.0.0.1:8080";
+// Real search requests have a 30-second upstream timeout plus configured retries.
+jest.setTimeout(105_000);
 
 describe("Search API", () => {
     it("should return validation error when search engine is invalid", async () => {
@@ -52,7 +54,7 @@ describe("Search API", () => {
         expect(response.body.data).toBeDefined();
         expect(response.body.data.length).toBeGreaterThan(0);
     });
-    it("should check lang and country is invalid", async () => {
+    it("preserves provider handling of an unsupported country", async () => {
         const response = await request(TEST_URL).post("/v1/search").send({
             query: "keyword",
             lang: "en",
@@ -62,15 +64,16 @@ describe("Search API", () => {
         expect(response.body.success).toBe(true);
         expect(response.body.data).toBeInstanceOf(Array);
         expect(response.body.data.length).toBeGreaterThan(0);
+    });
 
+    it("returns a parameter error when the upstream rejects the language", async () => {
         const response2 = await request(TEST_URL).post("/v1/search").send({
             query: "keyword",
             lang: "invalid-lang",
             country: "US",
         });
-        expect(response2.status).toBe(200);
-        expect(response2.body.success).toBe(true);
-        expect(response2.body.data).toBeInstanceOf(Array);
-        expect(response2.body.data.length).toBeGreaterThan(0);
+        expect(response2.status).toBe(400);
+        expect(response2.body).toMatchObject({ success: false, error: "SEARCH_INVALID_REQUEST", upstream_status: 400 });
+        expect(response2.body).not.toHaveProperty("data");
     });
 });

--- a/apps/api/src/__tests__/searchService.errors.test.ts
+++ b/apps/api/src/__tests__/searchService.errors.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+
+const get = jest.fn<(...args: any[]) => Promise<any>>();
+jest.unstable_mockModule("@anycrawl/scrape", () => ({ HttpClient: { get } }));
+const { SearchService } = await import("@anycrawl/search/SearchService");
+
+const result = { title: "Fixture result", url: "https://example.com/", content: "A result", engine: "google" };
+const response = (status: number, results: any[] = []) => ({ status, headers: {}, data: { results } });
+const service = () => new SearchService({ defaultEngine: "searxng", enabledEngines: ["searxng"], searxngUrl: "http://search-fixture.invalid" });
+
+beforeEach(() => { get.mockReset(); });
+
+describe("SearchService upstream errors", () => {
+    it("preserves a successful empty result", async () => {
+        get.mockResolvedValue(response(200));
+        const onPage = jest.fn<(...args: any[]) => Promise<void>>(async () => {});
+        await expect(service().search("searxng", { query: "empty" }, onPage)).resolves.toEqual([]);
+        expect(onPage).toHaveBeenCalledWith(1, [], "searxng", true);
+    });
+
+    it("handles an empty query without sending an invalid upstream request", async () => {
+        const onPage = jest.fn<(...args: any[]) => Promise<void>>(async () => {});
+        await expect(service().search("searxng", { query: "" }, onPage)).resolves.toEqual([]);
+        expect(get).not.toHaveBeenCalled();
+        expect(onPage).toHaveBeenCalledWith(1, [], "searxng", true);
+    });
+
+    it.each([400, 422])("propagates upstream parameter rejection (%i)", async (status) => {
+        get.mockResolvedValue(response(status));
+        const onPage = jest.fn<(...args: any[]) => Promise<void>>(async () => {});
+        await expect(service().search("searxng", { query: "keyword", lang: "invalid-lang" }, onPage)).rejects.toMatchObject({
+            code: "SEARCH_INVALID_REQUEST", httpStatus: 400, upstreamStatus: status,
+        });
+        expect(onPage).toHaveBeenCalledWith(1, [], "searxng", false);
+    });
+
+    it.each([401, 403, 429, 500, 502, 503])("reports upstream HTTP %i as a gateway failure", async (status) => {
+        get.mockResolvedValue(response(status));
+        await expect(service().search("searxng", { query: "keyword" })).rejects.toMatchObject({
+            code: "SEARCH_UPSTREAM_ERROR", httpStatus: 502, upstreamStatus: status,
+        });
+    });
+
+    it("reports transport errors without leaking upstream credentials", async () => {
+        get.mockRejectedValue(new Error("connect failed http://user:private-password@proxy.invalid"));
+        await expect(service().search("searxng", { query: "keyword" })).rejects.toMatchObject({
+            code: "SEARCH_UPSTREAM_ERROR", httpStatus: 502, message: "Search upstream request failed",
+        });
+    });
+
+    it.each([false, true])("withholds partial success when any page fails (concurrent=%s)", async (concurrent) => {
+        get.mockImplementation(async (url: string) => new URL(url).searchParams.get("pageno") === "1" ? response(200, [result]) : response(502));
+        const onPage = jest.fn<(...args: any[]) => Promise<void>>(async () => {});
+        await expect(service().search("searxng", { query: "keyword", limit: 20, concurrent }, onPage)).rejects.toMatchObject({ code: "SEARCH_UPSTREAM_ERROR" });
+        expect(onPage).toHaveBeenCalledTimes(1);
+        expect(onPage).toHaveBeenCalledWith(2, [], "searxng", false);
+    });
+
+    it("awaits successful page callbacks in page order", async () => {
+        get.mockResolvedValue(response(200, [result]));
+        const handled: number[] = [];
+        const results = await service().search("searxng", { query: "keyword", limit: 20, concurrent: true }, async (page) => {
+            await new Promise(resolve => setTimeout(resolve, 5));
+            handled.push(page);
+        });
+        expect(handled).toEqual([1, 2]);
+        expect(results).toHaveLength(2);
+    });
+});

--- a/apps/api/src/controllers/v1/SearchController.ts
+++ b/apps/api/src/controllers/v1/SearchController.ts
@@ -1,6 +1,6 @@
 import { Response } from "express";
 import { z } from "zod";
-import { SearchService, getSearchConfig } from "@anycrawl/search/SearchService";
+import { SearchService, SearchServiceError, getSearchConfig } from "@anycrawl/search/SearchService";
 import { log } from "@anycrawl/libs/log";
 import { searchSchema, RequestWithAuth, CreditCalculator, WebhookEventType, estimateTaskCredits, getCacheConfig, appConfig } from "@anycrawl/libs";
 import { randomUUID } from "crypto";
@@ -65,6 +65,9 @@ export class SearchController {
         let searchJobId: string | null = null;
         let engineName: string | null = null;
         let defaultPrice: number = 0;
+        let pagesProcessed = 0;
+        let failedPages = 0;
+        let successPages = 0;
         /** Search-template metadata: when false, do not bill scrape template perCall for follow-up scrapes. */
         let chargeScrapeTemplateCreditsForFollowup = true;
         try {
@@ -252,9 +255,6 @@ export class SearchController {
             );
 
             const expectedPages = validatedData.pages || 1;
-            let pagesProcessed = 0;
-            let failedPages = 0;
-            let successPages = 0;
 
             let scrapeJobIds: string[] = [];
             const scrapeJobCreationPromises: Promise<void>[] = [];
@@ -534,13 +534,29 @@ export class SearchController {
             } else {
                 if (searchJobId) {
                     try {
-                        await failedJob(searchJobId, error instanceof Error ? error.message : "Unknown error", false, { total: 0, completed: 0, failed: 0 });
+                        await failedJob(searchJobId, error instanceof Error ? error.message : "Unknown error", false, {
+                            total: pagesProcessed, completed: successPages, failed: failedPages,
+                        });
+                        if (error instanceof SearchServiceError) {
+                            await triggerWebhookEvent(WebhookEventType.SEARCH_FAILED, searchJobId, {
+                                status: "failed", error: error.code, message: error.message,
+                            }, "search");
+                        }
                     } catch (e) {
                         log.error(`Failed to mark job failed for job_id=${searchJobId}: ${e instanceof Error ? e.message : String(e)}`);
                     }
                 }
                 req.creditsUsed = 0;
                 req.billingChargeDetails = undefined;
+                if (error instanceof SearchServiceError) {
+                    res.status(error.httpStatus).json({
+                        success: false,
+                        error: error.code,
+                        message: error.message,
+                        ...(error.upstreamStatus === undefined ? {} : { upstream_status: error.upstreamStatus }),
+                    });
+                    return;
+                }
                 res.status(500).json({
                     success: false,
                     error: "Internal server error",

--- a/apps/docs/content/docs/general/search.mdx
+++ b/apps/docs/content/docs/general/search.mdx
@@ -400,6 +400,12 @@ The API returns two types of results:
 - **Language Targeting**: Specify language for region-specific and localized results
 - **Query Optimization**: Use specific keywords and phrases for better result quality
 
+### Upstream search failures
+
+An upstream parameter rejection (HTTP 400 or 422) returns HTTP 400 with `error: "SEARCH_INVALID_REQUEST"`. Other upstream HTTP failures or transport errors return HTTP 502 with `error: "SEARCH_UPSTREAM_ERROR"`. The body contains `success: false`, a safe `message`, and `upstream_status` when an HTTP response was received. Upstream authentication errors are gateway failures; they do not indicate an invalid AnyCrawl API key.
+
+Successful searches with no matches, including an empty query, still return `success: true` and `data: []`. An upstream error is never reported as a successful empty result. For a multi-page search, any failed page fails the request before successful-page callbacks can dispatch follow-up scrapes. Failed searches are not charged and do not write a successful Dataset result.
+
 ### Error Handling
 
 ```javascript

--- a/apps/docs/content/docs/general/search.zh-cn.mdx
+++ b/apps/docs/content/docs/general/search.zh-cn.mdx
@@ -400,6 +400,12 @@ API 返回两种类型的结果：
 - **语言定向**：指定语言以获取特定地区和本地化结果
 - **查询优化**：使用具体的关键词和短语以提升结果质量
 
+### 搜索上游失败
+
+上游因参数问题拒绝请求（HTTP 400 或 422）时，API 返回 HTTP 400，`error` 为 `SEARCH_INVALID_REQUEST`。其他上游 HTTP 错误或网络错误返回 HTTP 502，`error` 为 `SEARCH_UPSTREAM_ERROR`。响应包含 `success: false`、安全的 `message`，并在收到上游 HTTP 响应时附带 `upstream_status`。上游认证失败属于网关错误，不代表 AnyCrawl API key 无效。
+
+正常搜索没有匹配项以及空查询仍返回 `success: true`、`data: []`，上游错误不会被伪装成成功的空结果。多页搜索中任何一页失败，整次请求都会失败；成功页面的回调在全部页面成功后才执行，因此失败请求不会提前派发后续抓取。失败的搜索不计费，也不会写入成功的 Dataset 结果。
+
 ### 错误处理
 
 ```javascript

--- a/apps/docs/openapi.json
+++ b/apps/docs/openapi.json
@@ -2501,78 +2501,117 @@
             }
           },
           "400": {
-            "description": "Bad request - validation error",
+            "description": "Bad request - validation error or upstream parameter rejection",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "const": false,
-                      "description": "Indicates the request failed"
-                    },
-                    "error": {
-                      "type": "string",
-                      "description": "Error message",
-                      "example": "Validation error"
-                    },
-                    "details": {
+                  "anyOf": [
+                    {
                       "type": "object",
                       "properties": {
-                        "issues": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "field": {
-                                "type": "string",
-                                "description": "The field that caused the error",
-                                "example": "engine"
-                              },
-                              "message": {
-                                "type": "string",
-                                "description": "Error message for the field",
-                                "example": "Invalid enum value. Expected 'playwright' | 'cheerio' | 'puppeteer', received 'cheeri1o'"
-                              },
-                              "code": {
-                                "type": "string",
-                                "description": "Error code",
-                                "example": "invalid_enum_value"
-                              }
-                            },
-                            "required": [
-                              "field",
-                              "message",
-                              "code"
-                            ]
-                          },
-                          "description": "Array of validation issues"
+                        "success": {
+                          "type": "boolean",
+                          "const": false,
+                          "description": "Indicates the request failed"
                         },
-                        "messages": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
+                        "error": {
+                          "type": "string",
+                          "description": "Error message",
+                          "example": "Validation error"
+                        },
+                        "details": {
+                          "type": "object",
+                          "properties": {
+                            "issues": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "field": {
+                                    "type": "string",
+                                    "description": "The field that caused the error",
+                                    "example": "engine"
+                                  },
+                                  "message": {
+                                    "type": "string",
+                                    "description": "Error message for the field",
+                                    "example": "Invalid enum value. Expected 'auto' | 'playwright' | 'cheerio' | 'puppeteer', received 'cheeri1o'"
+                                  },
+                                  "code": {
+                                    "type": "string",
+                                    "description": "Error code",
+                                    "example": "invalid_enum_value"
+                                  }
+                                },
+                                "required": [
+                                  "field",
+                                  "message",
+                                  "code"
+                                ]
+                              },
+                              "description": "Array of validation issues"
+                            },
+                            "messages": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "description": "Array of validation error messages",
+                              "example": [
+                                "Invalid enum value. Expected 'auto' | 'playwright' | 'cheerio' | 'puppeteer', received 'cheeri1o'"
+                              ]
+                            }
                           },
-                          "description": "Array of validation error messages",
-                          "example": [
-                            "Invalid enum value. Expected 'playwright' | 'cheerio' | 'puppeteer', received 'cheeri1o'"
+                          "required": [
+                            "issues",
+                            "messages"
+                          ],
+                          "description": "Validation error details"
+                        }
+                      },
+                      "required": [
+                        "success",
+                        "error",
+                        "details"
+                      ],
+                      "description": "Standard error response format for validation errors"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "const": false
+                        },
+                        "error": {
+                          "type": "string",
+                          "const": "SEARCH_INVALID_REQUEST"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "upstream_status": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "const": 400
+                            },
+                            {
+                              "type": "number",
+                              "const": 422
+                            }
                           ]
                         }
                       },
                       "required": [
-                        "issues",
-                        "messages"
+                        "success",
+                        "error",
+                        "message",
+                        "upstream_status"
                       ],
-                      "description": "Validation error details"
+                      "description": "The search upstream rejected the request parameters"
                     }
-                  },
-                  "required": [
-                    "success",
-                    "error",
-                    "details"
-                  ],
-                  "description": "Standard error response format for validation errors"
+                  ]
                 }
               }
             }
@@ -2670,6 +2709,38 @@
                     "message"
                   ],
                   "description": "Internal server error response format"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Search upstream HTTP or transport failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string",
+                      "const": "SEARCH_UPSTREAM_ERROR"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "upstream_status": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                    "message"
+                  ],
+                  "description": "Search upstream HTTP or transport failure; contains no raw upstream credentials or error body"
                 }
               }
             }

--- a/apps/docs/openapi.template.json
+++ b/apps/docs/openapi.template.json
@@ -1529,78 +1529,117 @@
             }
           },
           "400": {
-            "description": "Bad request - validation error",
+            "description": "Bad request - validation error or upstream parameter rejection",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "properties": {
-                    "success": {
-                      "type": "boolean",
-                      "const": false,
-                      "description": "Indicates the request failed"
-                    },
-                    "error": {
-                      "type": "string",
-                      "description": "Error message",
-                      "example": "Validation error"
-                    },
-                    "details": {
+                  "anyOf": [
+                    {
                       "type": "object",
                       "properties": {
-                        "issues": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "field": {
-                                "type": "string",
-                                "description": "The field that caused the error",
-                                "example": "engine"
-                              },
-                              "message": {
-                                "type": "string",
-                                "description": "Error message for the field",
-                                "example": "Invalid enum value. Expected 'playwright' | 'cheerio' | 'puppeteer', received 'cheeri1o'"
-                              },
-                              "code": {
-                                "type": "string",
-                                "description": "Error code",
-                                "example": "invalid_enum_value"
-                              }
-                            },
-                            "required": [
-                              "field",
-                              "message",
-                              "code"
-                            ]
-                          },
-                          "description": "Array of validation issues"
+                        "success": {
+                          "type": "boolean",
+                          "const": false,
+                          "description": "Indicates the request failed"
                         },
-                        "messages": {
-                          "type": "array",
-                          "items": {
-                            "type": "string"
+                        "error": {
+                          "type": "string",
+                          "description": "Error message",
+                          "example": "Validation error"
+                        },
+                        "details": {
+                          "type": "object",
+                          "properties": {
+                            "issues": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "field": {
+                                    "type": "string",
+                                    "description": "The field that caused the error",
+                                    "example": "engine"
+                                  },
+                                  "message": {
+                                    "type": "string",
+                                    "description": "Error message for the field",
+                                    "example": "Invalid enum value. Expected 'auto' | 'playwright' | 'cheerio' | 'puppeteer', received 'cheeri1o'"
+                                  },
+                                  "code": {
+                                    "type": "string",
+                                    "description": "Error code",
+                                    "example": "invalid_enum_value"
+                                  }
+                                },
+                                "required": [
+                                  "field",
+                                  "message",
+                                  "code"
+                                ]
+                              },
+                              "description": "Array of validation issues"
+                            },
+                            "messages": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              },
+                              "description": "Array of validation error messages",
+                              "example": [
+                                "Invalid enum value. Expected 'auto' | 'playwright' | 'cheerio' | 'puppeteer', received 'cheeri1o'"
+                              ]
+                            }
                           },
-                          "description": "Array of validation error messages",
-                          "example": [
-                            "Invalid enum value. Expected 'playwright' | 'cheerio' | 'puppeteer', received 'cheeri1o'"
+                          "required": [
+                            "issues",
+                            "messages"
+                          ],
+                          "description": "Validation error details"
+                        }
+                      },
+                      "required": [
+                        "success",
+                        "error",
+                        "details"
+                      ],
+                      "description": "Standard error response format for validation errors"
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "success": {
+                          "type": "boolean",
+                          "const": false
+                        },
+                        "error": {
+                          "type": "string",
+                          "const": "SEARCH_INVALID_REQUEST"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "upstream_status": {
+                          "anyOf": [
+                            {
+                              "type": "number",
+                              "const": 400
+                            },
+                            {
+                              "type": "number",
+                              "const": 422
+                            }
                           ]
                         }
                       },
                       "required": [
-                        "issues",
-                        "messages"
+                        "success",
+                        "error",
+                        "message",
+                        "upstream_status"
                       ],
-                      "description": "Validation error details"
+                      "description": "The search upstream rejected the request parameters"
                     }
-                  },
-                  "required": [
-                    "success",
-                    "error",
-                    "details"
-                  ],
-                  "description": "Standard error response format for validation errors"
+                  ]
                 }
               }
             }
@@ -1698,6 +1737,38 @@
                     "message"
                   ],
                   "description": "Internal server error response format"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Search upstream HTTP or transport failure",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "const": false
+                    },
+                    "error": {
+                      "type": "string",
+                      "const": "SEARCH_UPSTREAM_ERROR"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "upstream_status": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "success",
+                    "error",
+                    "message"
+                  ],
+                  "description": "Search upstream HTTP or transport failure; contains no raw upstream credentials or error body"
                 }
               }
             }

--- a/apps/docs/scripts/generate-openapi.ts
+++ b/apps/docs/scripts/generate-openapi.ts
@@ -623,6 +623,20 @@ const errorResponseSchema = z.object({
     description: 'Standard error response format for validation errors'
 });
 
+const searchInvalidRequestResponseSchema = z.object({
+    success: z.literal(false),
+    error: z.literal('SEARCH_INVALID_REQUEST'),
+    message: z.string(),
+    upstream_status: z.union([z.literal(400), z.literal(422)]),
+}).openapi({ description: 'The search upstream rejected the request parameters' });
+
+const searchUpstreamErrorResponseSchema = z.object({
+    success: z.literal(false),
+    error: z.literal('SEARCH_UPSTREAM_ERROR'),
+    message: z.string(),
+    upstream_status: z.number().int().optional(),
+}).openapi({ description: 'Search upstream HTTP or transport failure; contains no raw upstream credentials or error body' });
+
 const InsufficientCreditsResponseSchema = z.object({
     success: z.literal(false).openapi({
         description: 'Indicates the request failed due to insufficient credits'
@@ -1082,10 +1096,10 @@ const document = createDocument({
                         }
                     },
                     '400': {
-                        description: 'Bad request - validation error',
+                        description: 'Bad request - validation error or upstream parameter rejection',
                         content: {
                             'application/json': {
-                                schema: errorResponseSchema
+                                schema: z.union([errorResponseSchema, searchInvalidRequestResponseSchema])
                             }
                         }
                     },
@@ -1103,6 +1117,12 @@ const document = createDocument({
                             'application/json': {
                                 schema: InsufficientCreditsResponseSchema
                             }
+                        }
+                    },
+                    '502': {
+                        description: 'Search upstream HTTP or transport failure',
+                        content: {
+                            'application/json': { schema: searchUpstreamErrorResponseSchema }
                         }
                     },
                     '500': {

--- a/docs/reviews/release-beta37-validation-fixes.md
+++ b/docs/reviews/release-beta37-validation-fixes.md
@@ -1,0 +1,40 @@
+# beta.37 发布验收修复
+
+2026-09-07。用户已授权修正验收中发现的测试契约、搜索错误传播及验证预算问题，并继续原发版任务。
+
+## 原因与修改
+
+- 抓取测试未请求 HTML 却读取 `data.html`，并要求 example.com 包含 `200 ok`。用例现在显式请求 HTML/Markdown，验证实际 `Example Domain` 内容；另保留默认只返回 Markdown 的回归。
+- httpstat.us 的 403/404 目标在当前网络中出现 CONNECT/TLS 超时及 502，不能稳定提供目标状态。状态语义测试改为进程内启动的真实 HTTP origin 和仅允许连接该 origin 的 loopback 代理，继续经过 API、队列和 Cheerio Worker。实际 HTTP 404 按现有公开文档验证为失败抓取，修正原测试将它当成功的预期。
+- 外部 example.com 和 expired.badssl.com 的三引擎请求保留，用于验证真实代理/浏览器与既有 SSL 策略。它们不证明商业代理访问外部 403/404 站点的覆盖；状态语义与外部连通性分别记录。
+- JSON 抽取测试现在验证任务为 completed、JSON 存在且满足输出结构和实际页面内容。输入拒绝测试保持短预算，不调用 LLM。根数组沿用现有 `{items: [...]}` 输出包装。
+- 真实抓取/JSON 请求使用 120 秒请求预算与 135 秒 Jest 预算，与 auto-proxy 的文档预算一致；真实多次 LLM 调用使用 120 秒功能预算，并输出耗时。未改变生产超时、模型或 provider，不将功能通过视为满足原来的 30 秒性能目标。
+- AI 自定义提示词测试使用与抽取意图一致的 schema，验证公司名称按提示词转为大写、成立年份正确；不再同时要求 industry 必填和缺失。两段抽取仍校验分段数与有效内容。
+
+## 搜索错误契约
+
+- `SearchService` 检查上游 HTTP 状态，400/422 对应 `SearchServiceError` 的 `SEARCH_INVALID_REQUEST`；其余非 2xx 或传输错误对应 `SEARCH_UPSTREAM_ERROR`。错误消息不包含上游地址、凭据或原始错误正文。
+- API 分别返回 HTTP 400/502，`success: false`，以及可用时的 `upstream_status`。正常零结果和空查询仍成功返回空数组。
+- 多页搜索先收集全部页面；任一页失败时不交付成功页面回调，避免失败搜索提前派发后续抓取。失败页面回调仍被等待和记录；成功时按页顺序等待回调。
+- API 将失败搜索记为 failed、发出既有失败 Webhook，并将请求计费归零，不写成功 Dataset 结果。
+- 定时搜索沿用现有异常终结路径，因此上游失败不再被当作成功的空结果计费。Map 的搜索发现保留自身错误处理逻辑。
+
+## 验证
+
+- 新增 14 个 SearchService 回归：修复前 13 失败/1 通过，修复后 14 通过。覆盖 400/422、401/403/429/5xx、传输错误、正常空结果、空查询、顺序/并行多页失败和异步回调顺序。
+- 全仓库 typecheck：16/16 任务通过，无缓存。
+- 全套测试：15/15 任务通过，无缓存；706 tests 通过，保留原有 20 个 opt-in 跳过（API 17、scrape 3），没有新增 skip。API 12 suites / 102 tests、AI 20 tests 均通过。
+- 实际调用原有 `custom/glm-4.5` 模型；本轮两段抽取耗时 85,173 ms，功能验证通过，不代表满足 30 秒性能目标。
+- 隔离 SQLite 中的失败搜索已核验为 `status=failed`、`credits_used=0`、`total=1`、`completed=0`、`failed=1`。
+- 最终生产构建：9/9 任务通过，无缓存；公开文档 330 页构建完成。
+- OpenAPI 生成器及普通/template 规范同步搜索 400/502 响应；结构比较确认其他端点及响应未改变。规范更新后的 docs typecheck 和 production build 再次通过。
+
+## Docs consulted
+
+- [Jest 配置](../jest-config-guide.md)
+- [搜索计费与后续抓取约定](../api/search-scrape-credits-and-templates.md)
+- [缓存](../cache.md)
+- [先前监控验收与迁移](./web-change-monitoring-fix-validation-2026-09-06.md)
+- [中文抓取接口](../../apps/docs/content/docs/general/scrape.zh-cn.mdx)
+- [英文搜索接口](../../apps/docs/content/docs/general/search.mdx)
+- [中文搜索接口](../../apps/docs/content/docs/general/search.zh-cn.mdx)

--- a/packages/ai/src/__tests__/llmExtract.test.ts
+++ b/packages/ai/src/__tests__/llmExtract.test.ts
@@ -5,6 +5,8 @@ import { ensureAIConfigLoaded, getAIConfig } from '../utils/config.js';
 import { getExtractModelId } from '../utils/helper.js';
 
 (globalThis as any).AI_SDK_LOG_WARNINGS = false;
+// Real model calls may include multiple sequential chunks; latency remains reported.
+const LIVE_LLM_TIMEOUT = 120_000;
 // 测试数据
 const testMarkdown = `
 # Company Information
@@ -258,7 +260,7 @@ describe('LLMExtract', () => {
             expect(result.data.companyName).toBeDefined();
             expect(typeof result.data.companyName).toBe('string');
             expect(result.data.industry).toBeDefined();
-        }, 60000);
+        }, LIVE_LLM_TIMEOUT);
 
         test('should handle empty text', async () => {
             const result = await extractor.perform('', simpleSchema);
@@ -268,7 +270,7 @@ describe('LLMExtract', () => {
 
             expect(result.data.companyName === null).toBe(true);
             expect(result.data.industry === null).toBe(true);
-        }, 30000);
+        }, LIVE_LLM_TIMEOUT);
 
     });
 
@@ -287,7 +289,7 @@ describe('LLMExtract', () => {
             if (result.data.services) {
                 expect(Array.isArray(result.data.services)).toBe(true);
             }
-        }, 30000);
+        }, LIVE_LLM_TIMEOUT);
 
         test('should handle long text with chunking', async () => {
             const result = await extractor.perform(longTestMarkdown, companySchema);
@@ -318,19 +320,28 @@ describe('LLMExtract', () => {
             // check employees exists
             expect(result.data.employees).toBeDefined();
             expect(typeof result.data.employees).toBe('number');
-        }, 60000);
+        }, LIVE_LLM_TIMEOUT);
     });
 
     describe('Custom Options Tests', () => {
         test('should use custom prompt', async () => {
-            const customPrompt = 'Extract only the company name and founding year from this text.';
-            const result = await extractor.perform(testMarkdown, simpleSchema, {
+            const customPrompt = 'Extract only the company name and founding year. Return companyName in UPPERCASE.';
+            const focusedSchema: JSONSchema7 = {
+                type: 'object',
+                properties: { companyName: { type: 'string' }, founded: { type: 'string' } },
+                required: ['companyName', 'founded'],
+                additionalProperties: false,
+            };
+            const result = await extractor.perform(testMarkdown, focusedSchema, {
                 prompt: customPrompt
             });
             expect(result).toBeDefined();
             expect(result.data).toBeDefined();
-            expect(result.data.industry === undefined || result.data.industry === null).toBe(true);
-        }, 30000);
+            expect(result.data.companyName).toMatch(/TECHCORP/);
+            expect(result.data.companyName).toBe(result.data.companyName.toUpperCase());
+            expect(result.data.founded).toContain('2015');
+            expect(result.data).not.toHaveProperty('industry');
+        }, LIVE_LLM_TIMEOUT);
 
         test('should use custom system prompt', async () => {
             const customSystemPrompt = 'You are a specialized data extraction assistant. Focus on accuracy and completeness.';
@@ -342,7 +353,7 @@ describe('LLMExtract', () => {
             expect(result.data).toBeDefined();
             expect(result.data.industry).toBeDefined();
             expect(result.data.industry !== null).toBe(true);
-        }, 30000);
+        }, LIVE_LLM_TIMEOUT);
 
         test('should respect token limits', async () => {
             const result = await extractor.perform(longTestMarkdown, simpleSchema, {
@@ -353,7 +364,10 @@ describe('LLMExtract', () => {
             expect(result.data).toBeDefined();
 
             expect(result.chunks).toBe(2);
-        }, 30000);
+            expect(result.data.companyName).toMatch(/TechCorp/i);
+            expect(Array.isArray(result.data.industry)).toBe(true);
+            console.info(`Two-chunk extraction duration: ${result.durationMs} ms`);
+        }, LIVE_LLM_TIMEOUT);
     });
 
     describe('Array Input Tests', () => {
@@ -372,7 +386,7 @@ describe('LLMExtract', () => {
             expect(result.data.industry).toBeDefined();
             expect(result.data.founded).toBeDefined();
 
-        }, 30000);
+        }, LIVE_LLM_TIMEOUT);
     });
 
     describe('Error Handling Tests', () => {
@@ -384,7 +398,7 @@ describe('LLMExtract', () => {
             const result = await extractor.perform(testMarkdown, invalidSchema);
 
             expect(result).toBeDefined();
-        }, 30000);
+        }, LIVE_LLM_TIMEOUT);
 
         test('should handle invalid model id', async () => {
             expect.assertions(2);
@@ -397,7 +411,7 @@ describe('LLMExtract', () => {
                     error instanceof Error && error.message.includes('Model invalid-model-id is not found')
                 ).toBe(true);
             }
-        }, 30000);
+        }, LIVE_LLM_TIMEOUT);
     });
 
 
@@ -417,7 +431,7 @@ describe('LLMExtract', () => {
             expect(result.chunks).toBeGreaterThan(0);
             expect(result.data).toBeDefined();
             expect(result.data.company).toBeDefined();
-        }, 30000);
+        }, LIVE_LLM_TIMEOUT);
 
         test('should respect cost limits', async () => {
             const lowCostExtractor = new LLMExtract(defaultLLMModel, undefined, 0.001); // 很低的成本限制
@@ -429,6 +443,6 @@ describe('LLMExtract', () => {
                 expect(error instanceof Error).toBe(true);
                 expect((error as Error).message.includes('Cost limit exceeded')).toBe(true);
             }
-        }, 60000);
+        }, LIVE_LLM_TIMEOUT);
     });
 });

--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@anycrawl/js-sdk",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/any4ai/AnyCrawl.git"

--- a/packages/search/src/SearchService.ts
+++ b/packages/search/src/SearchService.ts
@@ -7,6 +7,19 @@ import { HttpClient } from "@anycrawl/scrape";
 import { log, config as globalConfig } from "@anycrawl/libs";
 import { AVAILABLE_SEARCH_ENGINES } from "@anycrawl/libs/constants";
 
+export class SearchServiceError extends Error {
+    readonly code: "SEARCH_INVALID_REQUEST" | "SEARCH_UPSTREAM_ERROR";
+    readonly httpStatus: 400 | 502;
+
+    constructor(readonly upstreamStatus?: number) {
+        const invalidRequest = upstreamStatus === 400 || upstreamStatus === 422;
+        super(invalidRequest ? "Search upstream rejected request parameters" : "Search upstream request failed");
+        this.name = "SearchServiceError";
+        this.code = invalidRequest ? "SEARCH_INVALID_REQUEST" : "SEARCH_UPSTREAM_ERROR";
+        this.httpStatus = invalidRequest ? 400 : 502;
+    }
+}
+
 export interface SearchServiceConfig {
     defaultEngine?: string;
     enabledEngines?: string[];
@@ -206,111 +219,115 @@ export class SearchService {
     async search(
         engineName: string | undefined,
         options: SearchOptions,
-        onPage?: (page: number, results: SearchResult[], uniqueKey: string, success: boolean) => void,
+        onPage?: (page: number, results: SearchResult[], uniqueKey: string, success: boolean) => void | Promise<void>,
     ): Promise<SearchResult[]> {
         log.info("Search called with options:", options);
 
-        try {
-            // Use default engine if none provided
-            const actualEngineName = engineName || this.config.defaultEngine || 'default';
-            const engine = this.getEngine(actualEngineName);
-            const allResults: SearchResult[] = [];
+        // Use default engine if none provided
+        const actualEngineName = engineName || this.config.defaultEngine || 'default';
+        const engine = this.getEngine(actualEngineName);
+        const allResults: SearchResult[] = [];
 
-            // Determine effective pages
-            const perPage = 10; // Default page size per request for engines that do not support direct limit
-            let effectivePages = options.pages ?? 1;
-            if (typeof options.limit === 'number' && options.limit > 0) {
-                // If engine supports direct limit, one request is enough
-                if ((engine as any).supportsDirectLimit) {
-                    effectivePages = 1;
-                } else {
-                    effectivePages = Math.ceil(options.limit / perPage);
-                }
-            }
-
-            log.info(`Executing search for: ${actualEngineName}, pages: ${effectivePages}, concurrent: ${options.concurrent ?? false}`);
-
-            // Helper function to fetch a single page
-            const fetchPage = async (pageNum: number): Promise<{ pageNum: number; results: SearchResult[]; success: boolean }> => {
-                try {
-                    // Build task options
-                    const taskOptions: any = { ...options, page: pageNum };
-                    if (typeof options.limit === 'number' && options.limit > 0) {
-                        // If engine does not support direct limit, enforce per-page limit
-                        if (!(engine as any).supportsDirectLimit) {
-                            taskOptions.limit = perPage;
-                        }
-                    }
-                    const task: SearchTask = await engine.search(taskOptions);
-
-                    log.info(`Fetching page ${pageNum}: ${task.url} requireProxy=${task.requireProxy}`);
-
-                    // Prepare cookie header if cookies are present
-                    const cookieHeader = task.cookies && Object.keys(task.cookies).length > 0
-                        ? Object.entries(task.cookies).map(([key, value]) => `${key}=${value}`).join('; ')
-                        : undefined;
-
-                    // Make HTTP request using HttpClient
-                    const response = await HttpClient.get(task.url, {
-                        headers: task.headers,
-                        cookieHeader: cookieHeader,
-                        requireProxy: task.requireProxy === true,
-                        timeoutMs: 30000,
-                        retries: 2,
-                    });
-
-                    // Parse the response
-                    const html = response.rawText || response.data;
-                    const results = await engine.parse(html, { url: task.url, page: pageNum });
-
-                    log.info(`Page ${pageNum} returned ${results.length} results`);
-
-                    return { pageNum, results, success: true };
-                } catch (error) {
-                    log.error(`Error fetching page ${pageNum}: ${error}`);
-                    return { pageNum, results: [], success: false };
-                }
-            };
-
-            // Execute requests - concurrent or sequential based on options
-            if (options.concurrent) {
-                // Concurrent: fetch all pages in parallel
-                const pageNumbers = Array.from({ length: effectivePages }, (_, i) => i + 1);
-                const pageResults = await Promise.all(pageNumbers.map(fetchPage));
-
-                // Sort by page number and accumulate results
-                pageResults.sort((a, b) => a.pageNum - b.pageNum);
-                for (const { pageNum, results, success } of pageResults) {
-                    if (onPage) {
-                        onPage(pageNum, results, actualEngineName, success);
-                    }
-                    allResults.push(...results);
-                }
-            } else {
-                // Sequential: fetch pages one by one
-                for (let i = 0; i < effectivePages; i++) {
-                    const pageNum = i + 1;
-                    const { results, success } = await fetchPage(pageNum);
-
-                    if (onPage) {
-                        onPage(pageNum, results, actualEngineName, success);
-                    }
-                    allResults.push(...results);
-                }
-            }
-
-            // Apply limit if specified
-            const finalResults = typeof options.limit === 'number' && options.limit > 0
-                ? allResults.slice(0, options.limit)
-                : allResults;
-
-            log.info(`Search completed: ${finalResults.length} total results`);
-            return finalResults;
-
-        } catch (error) {
-            log.error(`Search execution error: ${error}`);
+        if (!options.query.trim()) {
+            await onPage?.(1, [], actualEngineName, true);
             return [];
         }
+
+        // Determine effective pages
+        const perPage = 10; // Default page size per request for engines that do not support direct limit
+        let effectivePages = options.pages ?? 1;
+        if (typeof options.limit === 'number' && options.limit > 0) {
+            // If engine supports direct limit, one request is enough
+            if ((engine as any).supportsDirectLimit) {
+                effectivePages = 1;
+            } else {
+                effectivePages = Math.ceil(options.limit / perPage);
+            }
+        }
+
+        log.info(`Executing search for: ${actualEngineName}, pages: ${effectivePages}, concurrent: ${options.concurrent ?? false}`);
+
+        // Helper function to fetch a single page
+        type PageResult = { pageNum: number; results: SearchResult[]; error?: SearchServiceError };
+        const fetchPage = async (pageNum: number): Promise<PageResult> => {
+            try {
+                // Build task options
+                const taskOptions: any = { ...options, page: pageNum };
+                if (typeof options.limit === 'number' && options.limit > 0) {
+                    // If engine does not support direct limit, enforce per-page limit
+                    if (!(engine as any).supportsDirectLimit) {
+                        taskOptions.limit = perPage;
+                    }
+                }
+                const task: SearchTask = await engine.search(taskOptions);
+
+                log.info(`Fetching page ${pageNum}: ${task.url} requireProxy=${task.requireProxy}`);
+
+                // Prepare cookie header if cookies are present
+                const cookieHeader = task.cookies && Object.keys(task.cookies).length > 0
+                    ? Object.entries(task.cookies).map(([key, value]) => `${key}=${value}`).join('; ')
+                    : undefined;
+
+                // Make HTTP request using HttpClient
+                const response = await HttpClient.get(task.url, {
+                    headers: task.headers,
+                    cookieHeader: cookieHeader,
+                    requireProxy: task.requireProxy === true,
+                    timeoutMs: 30000,
+                    retries: 2,
+                });
+
+                if (response.status < 200 || response.status >= 300) {
+                    throw new SearchServiceError(response.status);
+                }
+
+                // Parse the response
+                const html = response.rawText || response.data;
+                const results = await engine.parse(html, { url: task.url, page: pageNum });
+
+                log.info(`Page ${pageNum} returned ${results.length} results`);
+
+                return { pageNum, results };
+            } catch (error) {
+                const failure = error instanceof SearchServiceError ? error : new SearchServiceError();
+                log.error(`Error fetching search page ${pageNum}: ${failure.message}`);
+                return { pageNum, results: [], error: failure };
+            }
+        };
+
+        // Wait for all pages before successful callbacks can enqueue follow-up
+        // scrapes or account for results from an incomplete search.
+        const pageResults: PageResult[] = [];
+        if (options.concurrent) {
+            const pageNumbers = Array.from({ length: effectivePages }, (_, i) => i + 1);
+            pageResults.push(...await Promise.all(pageNumbers.map(fetchPage)));
+        } else {
+            for (let i = 0; i < effectivePages; i++) {
+                const page = await fetchPage(i + 1);
+                pageResults.push(page);
+                if (page.error) break;
+            }
+        }
+
+        const failedPages = pageResults.filter(page => page.error);
+        if (failedPages.length) {
+            for (const page of failedPages) await onPage?.(page.pageNum, [], actualEngineName, false);
+            throw failedPages[0]!.error;
+        }
+
+        for (const page of pageResults) {
+            await onPage?.(page.pageNum, page.results, actualEngineName, true);
+            allResults.push(...page.results);
+        }
+
+        // Apply limit if specified
+        const finalResults = typeof options.limit === 'number' && options.limit > 0
+            ? allResults.slice(0, options.limit)
+            : allResults;
+
+        log.info(`Search completed: ${finalResults.length} total results`);
+        return finalResults;
+
     }
 
 }


### PR DESCRIPTION
Search upstream failures were being parsed as successful empty results. This release returns explicit parameter/gateway errors, prevents partial searches from dispatching follow-up scrapes, and updates validation that depended on unrequested HTML, unavailable HTTP-status fixtures, and contradictory LLM expectations. It prepares AnyCrawl v1.0.0-beta.37 and JS SDK 0.0.9.

## Changes

- Return HTTP 400 (`SEARCH_INVALID_REQUEST`) for upstream 400/422 and HTTP 502 (`SEARCH_UPSTREAM_ERROR`) for other upstream/transport failures. Preserve successful empty searches; expose no raw upstream credentials or error bodies.
- Wait for all search pages before successful callbacks and await each callback. Failed searches are persisted as failed, emit the failure event, use zero credits, and do not write successful Dataset results or enqueue follow-up scrapes.
- Update English/Chinese documentation and the OpenAPI generator/specifications for the new response contract.
- Explicitly request HTML in tests that inspect it, verify actual page content and JSON output, and retain default-Markdown coverage. Exercise HTTP 403/404 through a real loopback origin/proxy, API, queue, and Cheerio worker.
- Keep external page/browser/SSL checks and the existing LLM provider. Align functional live budgets with the service contract; preserve latency reporting and resolve the custom-prompt/schema contradiction.
- Add release notes for the monitoring, template, and browser-runtime changes already merged in #99, and bump the monitoring SDK to 0.0.9.

## Validation

- pnpm 10.12.4 frozen installation passed; no dependency or lockfile changes.
- `pnpm test --force`: 15/15 tasks, no cache; **706 tests passed**, with 20 pre-existing opt-in skips (API 17, scrape 3), and no newly skipped tests.
- API: 102 tests across 12 suites, including 14 new error-propagation regressions; AI: 20 tests passed using the existing `custom/glm-4.5` model.
- The real invalid-language API request returned an error and its isolated SQLite job was failed with zero credits.
- `pnpm typecheck --force`: 16/16 tasks; `pnpm build --force`: 9/9 tasks; documentation production build generated 330 pages.
- OpenAPI generation passed; semantic comparison limited specification changes to `/v1/search` responses 400/502. Documentation typecheck/build passed again afterward.

The HTTP-status fixture proves status-handling semantics; external page/browser tests separately verify the retained proxy. Functional live checks now allow 120-second requests/model calls; the observed two-chunk LLM extraction took 85.2 seconds, so this is not a claim of a 30-second performance target.

[Detailed validation record](https://github.com/any4ai/AnyCrawl/blob/b68237e2f8340be7ffb0d1bc030b6af8a76b6f91/docs/reviews/release-beta37-validation-fixes.md)

## Upgrade

Search callers must handle explicit upstream errors instead of assuming all empty arrays mean a successful search.

For monitoring, stop/drain old producers, back up and migrate the database (PostgreSQL 0026; SQLite 0021/0022), then start the API, Scheduler, and Workers together. Do not run old and new monitoring producers concurrently or replay historical alerts. This release publishes artifacts; it does not migrate a production database.
