### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Validation and known limitations
 
-- Scrape regression suite: 400 passed, 7 existing optional tests skipped. Controlled headless flow checks and final DOM checks passed with both CloakBrowser drivers on macOS.
+- Release-worktree scrape regression suite: 393 passed, 7 existing optional tests skipped (400 total). Controlled headless flow checks and final DOM checks passed with both CloakBrowser drivers on macOS.
 - ScienceDirect validation covered a fixed 50-request matrix, 20-minute identity reuse, and a final-source five-page chain. The 120-minute supplier lifetime and all deployment platform combinations were not fully observed.
 - The historical intermittent 79-character response did not recur during follow-up sampling; its exact trigger remains unconfirmed. Observable error detection is improved, but arbitrary future page loading cannot be guaranteed complete.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-09-09
+
+### Added
+
+- Opt-in sticky proxy lifecycle management with a shared TTL, per-browser session identities, safe lease admission, and ordinary-context reuse.
+- Browser score tooling and regression coverage for CloakBrowser runtime behavior.
+
+### Fixed
+
+- Preserve healthy browser identities after content failures, distinguish origin restrictions from proxy/browser failures, and keep proxy fallback within configured permissions.
+- Share Cloudflare verification within the same browser context and origin while recovering each page independently.
+- Detect observable content failures before extraction, allow one bounded same-session recovery, and use one validated HTML snapshot across HTML-derived formats.
+- Preserve proxy authentication/transport errors during recovery, prevent unsafe replay after extraction or template side effects, and keep validation metadata internal to cache payloads.
+
+### Upgrade notes
+
+- Sticky management remains disabled by default. Enabling it requires a proxy username containing `{sessionId}` and a supplier session window that covers the complete request budget plus the existing safety margin. Application TTL does not change supplier settings.
+- Ordinary contexts are required for shared website state. Sticky management owns its browser leases and disables Crawlee SessionPool/cookie replay internally.
+- Sticky proxy preferences use an isolated, expiring cache policy; a single session failure does not blacklist the entire proxy template.
+- No new database migrations are included relative to beta.37. Server workspace packages move to 1.0.0; the independently versioned JS SDK remains at 0.0.9.
+
+### Validation and known limitations
+
+- Scrape regression suite: 400 passed, 7 existing optional tests skipped. Controlled headless flow checks and final DOM checks passed with both CloakBrowser drivers on macOS.
+- ScienceDirect validation covered a fixed 50-request matrix, 20-minute identity reuse, and a final-source five-page chain. The 120-minute supplier lifetime and all deployment platform combinations were not fully observed.
+- The historical intermittent 79-character response did not recur during follow-up sampling; its exact trigger remains unconfirmed. Observable error detection is improved, but arbitrary future page loading cannot be guaranteed complete.
+
 ## [1.0.0-beta.37] - 2026-09-07
 
 ### Added

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "api",
-    "version": "1.0.0-beta.26",
+    "version": "1.0.0",
     "private": true,
     "type": "module",
     "scripts": {

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@anycrawl/db",
-    "version": "1.0.0-beta.26",
+    "version": "1.0.0",
     "private": true,
     "type": "module",
     "scripts": {

--- a/packages/libs/package.json
+++ b/packages/libs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@anycrawl/libs",
-    "version": "1.0.0-beta.26",
+    "version": "1.0.0",
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/scrape/package.json
+++ b/packages/scrape/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@anycrawl/scrape",
-    "version": "1.0.0-beta.26",
+    "version": "1.0.0",
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",

--- a/packages/search/package.json
+++ b/packages/search/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@anycrawl/search",
-    "version": "1.0.0-beta.26",
+    "version": "1.0.0",
     "private": true,
     "type": "module",
     "scripts": {

--- a/packages/template-client/package.json
+++ b/packages/template-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@anycrawl/template-client",
-    "version": "1.0.0-beta.26",
+    "version": "1.0.0",
     "type": "module",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
Prepare the stable v1.0.0 release from main commit 401ada59c728063480fe2df07ea7ba0ced073715.

Update CHANGELOG.md and align the six server workspace packages still carrying 1.0.0-beta.26 to 1.0.0. Keep the independently versioned JS SDK at 0.0.9; no SDK publish or database migration is included.

The release covers sticky browser lifecycle/recovery, context-scoped CF verification, and content validation with consistent snapshots. The historical intermittent 79-character response remains unconfirmed; the notes retain this limitation.

Recorded validation: 393 scrape tests passed with 7 original optional skips (400 total) in the isolated release worktree, controlled headless checks for both drivers, real ScienceDirect matrix and 20-minute reuse. Main Docker CI succeeded; require this PR's configured checks and normal merge rules before tagging.

Pushing v1.0.0 triggers five Docker publishing workflows and updates Docker latest under the current configuration. Create the stable GitHub Release only after those workflows succeed.
